### PR TITLE
fix: prevent duplicate options

### DIFF
--- a/speak-easy-synthesis/script.js
+++ b/speak-easy-synthesis/script.js
@@ -13,7 +13,8 @@ var voices = [];
 
 function populateVoiceList() {
   voices = synth.getVoices();
-
+  var selectedIndex = voiceSelect.selectedIndex < 0 ? 0 : voiceSelect.selectedIndex;
+  voiceSelect.innerHTML = '';
   for(i = 0; i < voices.length ; i++) {
     var option = document.createElement('option');
     option.textContent = voices[i].name + ' (' + voices[i].lang + ')';
@@ -26,6 +27,7 @@ function populateVoiceList() {
     option.setAttribute('data-name', voices[i].name);
     voiceSelect.appendChild(option);
   }
+  voiceSelect.selectedIndex = selectedIndex;
 }
 
 populateVoiceList();


### PR DESCRIPTION
Duplicate options added when `populateVoiceList()` called multiple times.