### PR TITLE
Phrase correction

### DIFF
--- a/phrase-matcher/script.js
+++ b/phrase-matcher/script.js
@@ -3,7 +3,7 @@ var SpeechGrammarList = SpeechGrammarList || webkitSpeechGrammarList;
 var SpeechRecognitionEvent = SpeechRecognitionEvent || webkitSpeechRecognitionEvent;
 
 var phrases = [
-  'i love to sing because it\'s fun',
+  'I love to sing because it\'s fun',
   'where are you going',
   'can I call you tomorrow',
   'why did you talk while I was talking',


### PR DESCRIPTION
The pronoun I should be capitalized, otherwise the phrase won't match despite a correct recognition.